### PR TITLE
Missing ids

### DIFF
--- a/bluto/features/steps/steps.py
+++ b/bluto/features/steps/steps.py
@@ -16,8 +16,7 @@ def step_impl(context):
 # When
 @when("we generate a {number:d} of new {length:d} character posts")
 def step_impl(context, number, length):
-    data = mk.make_markov_model(context.post_list)
-    context.new_post_list = [data.make_short_sentence(length) for i in range(number)]
+    context.new_post_list = mk.make_markov_sentences(context.post_list, length, number)
     assert not (None in context.new_post_list)
 
 


### PR DESCRIPTION
Serve a 404 page instead of 500 when the Bluesky handle doesn't exist or we can't find it. This check happens before we try to get posts or any other aspects of a user's profile.

The `test_output = False` option for Markovify stops it from throwing out generated sentences if they're 'too similar' to the original corpus, which may have been causing the issue I was seeing with Behave tests failing. Instead of not testing the output at all we could also just change the threshold if we decide to
